### PR TITLE
fix settings page load failure

### DIFF
--- a/diskover-web/public/settings.php
+++ b/diskover-web/public/settings.php
@@ -25,7 +25,7 @@ try
 {
     $es_clusterstats = $client->cluster()->stats();
 }
-catch (Exception $e)
+catch (Throwable $e)
 {
 }
 


### PR DESCRIPTION
an issue with the ES client access was causing a fatal error but the settings page is necessary to configure the client.