### PR TITLE
plugins_files and plugins_dirs no longer defined

### DIFF
--- a/diskover/diskover.py
+++ b/diskover/diskover.py
@@ -486,7 +486,7 @@ def get_tree_size(thread, root, top, path, docs, sizes, inodes, depth=0, maxdept
                                             warnings += 1
                                         pass
                                 # check plugins for adding extra meta data to data dict
-                                if config['PLUGINS_ENABLE'] and plugins_files:
+                                if config['PLUGINS_ENABLE'] and config['PLUGINS_FILES']:
                                     for plugin in plugins:
                                         try:
                                             # check if plugin is for file doc
@@ -646,7 +646,7 @@ def get_tree_size(thread, root, top, path, docs, sizes, inodes, depth=0, maxdept
                         warnings += 1
                     pass
             # check plugins for adding extra meta data to data dict
-            if config['PLUGINS_ENABLE'] and plugins_dirs:
+            if config['PLUGINS_ENABLE'] and config['PLUGINS_DIRS']:
                 for plugin in plugins:
                     # check if plugin is for directory doc
                     try:


### PR DESCRIPTION
discover does not run if PLUGINS_ENABLE==True. I'm assuming this is what they need to reference based on git history

Fixes 73416533b4ec5e5d9d8164f83d4cbaee8063d4b6

```
2025-02-04 23:52:55,098 - diskover - CRITICAL - FATAL ERROR: an exception has occurred: name 'plugins_files' is not defined
Traceback (most recent call last):
  File "/app/diskover/diskover.py", line 836, in crawl
    data = future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/diskover/diskover.py", line 762, in crawl_thread
    size, size_du, file_count, dir_count = get_tree_size(thread, root, top, top, docs, sizes, inodes, depth, maxdepth)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/diskover/diskover.py", line 489, in get_tree_size
    if config['PLUGINS_ENABLE'] and plugins_files:
                                    ^^^^^^^^^^^^^
NameError: name 'plugins_files' is not defined. Did you mean: 'plugins_list'?
2025-02-04 23:52:55,111 - diskover - CRITICAL - CRITICAL ERROR, DELETING INDEX AND EXITING
```